### PR TITLE
Rename ibeis import references to wbia

### DIFF
--- a/utool/Preferences.py
+++ b/utool/Preferences.py
@@ -458,7 +458,7 @@ class Pref(PrefNode):
         try:
             #from utool._internal.PreferenceWidget import EditPrefWidget
             try:
-                from guitool_ibeis.PreferenceWidget import EditPrefWidget
+                from wbia.guitool.PreferenceWidget import EditPrefWidget
             except ImportError:
                 from guitool.PreferenceWidget import EditPrefWidget
             editpref_widget = EditPrefWidget(self)
@@ -602,13 +602,13 @@ def test_Preferences():
         >>> # FIXME depends on guitool_ibei
         >>> from utool.Preferences import *  # NOQA
         >>> import utool as ut
-        >>> import guitool_ibeis
-        >>> guitool_ibeis.ensure_qtapp()
+        >>> import wbia.guitool
+        >>> wbia.guitool.ensure_qtapp()
         >>> root = test_Preferences()
         >>> ut.quit_if_noshow()
         >>> widget = root.createQWidget()
         >>> #widget.show()
-        >>> guitool_ibeis.qtapp_loop(widget)
+        >>> wbia.guitool.qtapp_loop(widget)
     """
     root = Pref()
     root.a = Pref()

--- a/utool/experimental/dynamic_connectivity.py
+++ b/utool/experimental/dynamic_connectivity.py
@@ -117,7 +117,7 @@ class TestETT(object):
         >>> mst = nx.Graph(edges)
         >>> #mst = nx.balanced_tree(2, 11)
         >>> self = TestETT.from_tree(mst)
-        >>> import ibeis.plottool as pt
+        >>> import wbia.plottool as pt
         >>> pt.qt4ensure()
         >>> pt.show_nx(mst)
 
@@ -134,7 +134,7 @@ class TestETT(object):
         >>> from utool.experimental.dynamic_connectivity import *  # NOQA
         >>> mst = nx.balanced_tree(2, 4)
         >>> self = TestETT.from_tree(mst)
-        >>> import ibeis.plottool as pt
+        >>> import wbia.plottool as pt
         >>> pt.qt4ensure()
         >>> pt.show_nx(self.to_networkx(), pnum=(2, 1, 1), fnum=1)
 
@@ -406,7 +406,7 @@ class EulerTourTree(object):
         >>> ]
         >>> mst = nx.Graph(edges)
         >>> self = EulerTourTree.from_tree(mst)
-        >>> import ibeis.plottool as pt
+        >>> import wbia.plottool as pt
         >>> pt.qt4ensure()
         >>> fnum = 1
         >>> pnum_ = pt.make_pnum_nextgen(1, 3)
@@ -752,7 +752,7 @@ class DynConnGraph(object):
         >>> from utool.experimental.dynamic_connectivity import *  # NOQA
         >>> import networkx as nx
         >>> import utool as ut
-        >>> import ibeis.plottool as pt
+        >>> import wbia.plottool as pt
         >>> graph = nx.Graph([
         >>>    (0, 1), (0, 2), (0, 3), (1, 3), (2, 4), (3, 4), (2, 3),
         >>>    (5, 6), (5, 7), (5, 8), (6, 8), (7, 9), (8, 9), (7, 8),
@@ -770,7 +770,7 @@ class DynConnGraph(object):
     """
 
     def show_internals(self, fnum=None):
-        import ibeis.plottool as pt
+        import wbia.plottool as pt
         pt.qtensure()
 
         pnum_ = pt.make_pnum_nextgen(nRows=1, nCols=len(self.forests))
@@ -939,8 +939,8 @@ class DynConnGraph(object):
 if __name__ == '__main__':
     r"""
     CommandLine:
-        python -m ibeis.algo.hots.dynamic_connectivity
-        python -m ibeis.algo.hots.dynamic_connectivity --allexamples
+        python -m wbia.algo.hots.dynamic_connectivity
+        python -m wbia.algo.hots.dynamic_connectivity --allexamples
     """
     import multiprocessing
     multiprocessing.freeze_support()  # for win32

--- a/utool/util_autogen.py
+++ b/utool/util_autogen.py
@@ -80,7 +80,7 @@ def makeinit(mod_dpath, exclude_modnames=[], use_star=False):
         str: init_codeblock
 
     CommandLine:
-        python -m utool.util_autogen makeinit --modname=ibeis.algo
+        python -m utool.util_autogen makeinit --modname=wbia.algo
 
     Example:
         >>> # DISABLE_DOCTEST
@@ -412,7 +412,7 @@ def auto_docstr(modname, funcname, verbose=True, moddir=None, modpath=None, **kw
         >>> import utool as ut
         >>> from utool.util_autogen import *  # NOQA
         >>> ut.util_autogen.rrr(verbose=False)
-        >>> #docstr = ut.auto_docstr('ibeis.algo.hots.smk.smk_index', 'compute_negentropy_names')
+        >>> #docstr = ut.auto_docstr('wbia.algo.hots.smk.smk_index', 'compute_negentropy_names')
         >>> modname = ut.get_argval('--modname', default='utool.util_autogen')
         >>> funcname = ut.get_argval('--funcname', default='auto_docstr')
         >>> moddir = ut.get_argval('--moddir', type_=str, default=None)
@@ -443,9 +443,9 @@ def auto_docstr(modname, funcname, verbose=True, moddir=None, modpath=None, **kw
 
 def print_auto_docstr(modname, funcname):
     """
-    python -c "import utool; utool.print_auto_docstr('ibeis.algo.hots.smk.smk_index', 'compute_negentropy_names')"
+    python -c "import utool; utool.print_auto_docstr('wbia.algo.hots.smk.smk_index', 'compute_negentropy_names')"
     python -c "import utool;
-    utool.print_auto_docstr('ibeis.algo.hots.smk.smk_index', 'compute_negentropy_names')"
+    utool.print_auto_docstr('wbia.algo.hots.smk.smk_index', 'compute_negentropy_names')"
     """
     docstr = auto_docstr(modname, funcname)
     print(docstr)
@@ -575,10 +575,10 @@ def make_example_docstr(funcname=None, modname=None, argname_list=None,
         # DISABLE_DOCTEST
         from utool.util_autogen import *  # NOQA
         import utool as ut
-        import ibeis
-        species = ibeis.const.TEST_SPECIES.ZEB_PLAIN
+        import wbia
+        species = wbia.const.TEST_SPECIES.ZEB_PLAIN
         qaids = ibs.get_valid_aids(species=species)
-        qreq_ = ibeis.testdata_qreq_()
+        qreq_ = wbia.testdata_qreq_()
         foo = make_example_docstr(qaids, qreq_)
         result = ('foo = %s' % (ut.repr2(foo),))
         print(result)
@@ -596,16 +596,16 @@ def make_example_docstr(funcname=None, modname=None, argname_list=None,
 
     # TODO: Externally register these
     default_argval_map = {
-        'ibs'       : 'ibeis.opendb(defaultdb=\'testdb1\')',
-        'testres'   : 'ibeis.testdata_expts(\'PZ_MTEST\')',
-        'qreq_'     : 'ibeis.testdata_qreq_()',
+        'ibs'       : 'wbia.opendb(defaultdb=\'testdb1\')',
+        'testres'   : 'wbia.testdata_expts(\'PZ_MTEST\')',
+        'qreq_'     : 'wbia.testdata_qreq_()',
         'cm_list'   : 'qreq_.execute()',
         'cm'        : 'qreq_.execute()[0]',
         'aid_list'  : 'ibs.get_valid_aids()',
         'nid_list'  : 'ibs._get_all_known_nids()',
         'qaids'     : 'ibs.get_valid_aids(species=species)',
         'daids'     : 'ibs.get_valid_aids(species=species)',
-        'species'   : 'ibeis.const.TEST_SPECIES.ZEB_PLAIN',
+        'species'   : 'wbia.const.TEST_SPECIES.ZEB_PLAIN',
         'kpts'      : 'vt.dummy.get_dummy_kpts()',
         'dodraw'    : 'ut.show_was_requested()',
         'img_fpath' : 'ut.grab_test_imgpath(\'carl.jpg\')',

--- a/utool/util_cache.py
+++ b/utool/util_cache.py
@@ -694,7 +694,7 @@ def cachestr_repr(val):
             return to_json(val)
         except Exception:
             # SUPER HACK
-            if repr(val.__class__) == "<class 'ibeis.control.IBEISControl.IBEISController'>":
+            if repr(val.__class__) == "<class 'wbia.control.IBEISControl.IBEISController'>":
                 return val.get_dbname()
 
 

--- a/utool/util_class.py
+++ b/utool/util_class.py
@@ -80,10 +80,10 @@ def inject_instance(self, classkey=None, allow_override=False,
             # Probably should depricate this block of code
             # It tries to do too much
             classkey = self.__class__
-            if classkey == 'ibeis.gui.models_and_views.IBEISTableView':
+            if classkey == 'wbia.gui.models_and_views.IBEISTableView':
                 # HACK HACK HACK
                 try:
-                    from guitool_ibeis.__PYQT__ import QtWidgets  # NOQA
+                    from wbia.guitool.__PYQT__ import QtWidgets  # NOQA
                 except ImportError:
                     from guitool.__PYQT__ import QtWidgets  # NOQA
                 classkey = QtWidgets.QAbstractItemView
@@ -241,9 +241,9 @@ def autogen_explicit_injectable_metaclass(classname, regen_command=None,
         >>> # DISABLE_DOCTEST
         >>> from utool.util_class import *  # NOQA
         >>> from utool.util_class import  __CLASSTYPE_ATTRIBUTES__  # NOQA
-        >>> import ibeis
-        >>> import ibeis.control.IBEISControl
-        >>> classname = ibeis.control.controller_inject.CONTROLLER_CLASSNAME
+        >>> import wbia
+        >>> import wbia.control.IBEISControl
+        >>> classname = wbia.control.controller_inject.CONTROLLER_CLASSNAME
         >>> result = autogen_explicit_injectable_metaclass(classname)
         >>> print(result)
     """

--- a/utool/util_cplat.py
+++ b/utool/util_cplat.py
@@ -1282,7 +1282,7 @@ def change_term_title(title):
 
          printf "\e]2;newtitle\a";
 
-        echo -en "\033]0;DocTest /home/joncrall/code/ibeis/ibeis.algo.graph.core.py --test-AnnotInference._make_state_delta\a"
+        echo -en "\033]0;DocTest /home/joncrall/code/ibeis/wbia.algo.graph.core.py --test-AnnotInference._make_state_delta\a"
 
     Example:
         >>> # DISABLE_DOCTEST

--- a/utool/util_dbg.py
+++ b/utool/util_dbg.py
@@ -414,7 +414,7 @@ def _wip_embed(parent_locals=None, parent_globals=None, exec_lines=None,
         if remove_pyqt_hook:
             try:
                 try:
-                    import guitool_ibeis as gt
+                    import wbia.guitool as gt
                 except ImportError:
                     import guitool as gt
                 gt.remove_pyqt_input_hook()
@@ -487,7 +487,7 @@ def embed(parent_locals=None, parent_globals=None, exec_lines=None,
         if remove_pyqt_hook:
             try:
                 try:
-                    import guitool_ibeis as gt
+                    import wbia.guitool as gt
                 except ImportError:
                     import guitool as gt
                 gt.remove_pyqt_input_hook()

--- a/utool/util_dev.py
+++ b/utool/util_dev.py
@@ -325,7 +325,7 @@ def timeit_grid(stmt_list, setup='', iterations=10000, input_sizes=None,
     if show:
         time_grid = np.array(time_grid)
         try:
-            import ibeis.plottool as pt
+            import wbia.plottool as pt
         except ImportError:
             import plottool as pt
         color_list = pt.distinct_colors(len(stmt_list))
@@ -1656,10 +1656,10 @@ def get_object_nbytes(obj, fallback_type=None, follow_pointers=False, exclude_mo
         >>> # DISABLE_DOCTEST
         >>> # UNSTABLE_DOCTEST
         >>> from utool.util_dev import *  # NOQA
-        >>> import ibeis
+        >>> import wbia
         >>> import utool as ut
-        >>> species = ibeis.const.TEST_SPECIES.ZEB_PLAIN
-        >>> ibs = ibeis.opendb(defaultdb='testdb1')
+        >>> species = wbia.const.TEST_SPECIES.ZEB_PLAIN
+        >>> ibs = wbia.opendb(defaultdb='testdb1')
         >>> qaids = ibs.get_valid_aids(species=species)
         >>> daids = ibs.get_valid_aids(species=species)
         >>> qreq_ = ibs.new_query_request(qaids, daids, verbose=True)
@@ -2088,7 +2088,7 @@ def is_developer(mycomputers=None):
 def iup():
     """ shortcut when pt is not imported """
     try:
-        import ibeis.plottool as pt
+        import wbia.plottool as pt
     except ImportError:
         import plottool as pt
     pt.iup()
@@ -2354,7 +2354,7 @@ def get_submodules_from_dpath(dpath, only_packages=False, recursive=True):
 
 def pylab_qt4():
     try:
-        import ibeis.plottool as pt
+        import wbia.plottool as pt
     except ImportError:
         import plottool as pt
     pt.ensureqt()
@@ -2362,7 +2362,7 @@ def pylab_qt4():
 
 def ensureqt():
     try:
-        import ibeis.plottool as pt
+        import wbia.plottool as pt
     except ImportError:
         import plottool as pt
     pt.ensureqt()

--- a/utool/util_graph.py
+++ b/utool/util_graph.py
@@ -94,7 +94,7 @@ def nx_transitive_reduction(G, mode=1):
         >>> G_tr2 = nx_transitive_reduction(G, mode=1)
         >>> ut.quit_if_noshow()
         >>> try:
-        >>>     import ibeis.plottool as pt
+        >>>     import wbia.plottool as pt
         >>> except ImportError:
         >>>     import plottool as pt
         >>> G_ = nx.dag.transitive_closure(G)
@@ -1078,8 +1078,8 @@ def nx_from_matrix(weight_matrix, nodes=None, remove_self=True):
 def nx_ensure_agraph_color(graph):
     """ changes colors to hex strings on graph attrs """
     try:
-        from ibeis.plottool import color_funcs
-        import ibeis.plottool as pt
+        from wbia.plottool import color_funcs
+        import wbia.plottool as pt
     except ImportError:
         from plottool import color_funcs
         import plottool as pt
@@ -1836,7 +1836,7 @@ def color_nodes(graph, labelattr='label', brightness=.878,
                 outof=None, sat_adjust=None):
     """ Colors edges and nodes by nid """
     try:
-        import ibeis.plottool as pt
+        import wbia.plottool as pt
     except ImportError:
         import plottool as pt
     import utool as ut

--- a/utool/util_gridsearch.py
+++ b/utool/util_gridsearch.py
@@ -1711,7 +1711,7 @@ class GridSearch(object):
             >>> # DISABLE_DOCTEST
             >>> from utool.util_gridsearch import *  # NOQA
             >>> import utool as ut
-            >>> import ibeis.plottool as pt
+            >>> import wbia.plottool as pt
             >>> # build test data
             >>> score_lbl = 'score_diff'
             >>> gridsearch = testdata_grid_search()
@@ -1814,7 +1814,7 @@ class GridSearch(object):
         Example:
             >>> # DISABLE_DOCTEST
             >>> from utool.util_gridsearch import *  # NOQA
-            >>> import ibeis.plottool as pt
+            >>> import wbia.plottool as pt
             >>> # build test data
             >>> gridsearch = testdata_grid_search()
             >>> param_lbl = 'p'
@@ -1825,7 +1825,7 @@ class GridSearch(object):
             >>> self.plot_dimension('dcvs_clip_max', score_lbl, fnum=1, pnum=(1, 3, 3))
             >>> pt.show_if_requested()
         """
-        import ibeis.plottool as pt
+        import wbia.plottool as pt
         param2_score_stats = gridsearch.get_dimension_stats(param_lbl, score_lbl)
         title = param_lbl
         #title = param_lbl + ' vs ' + score_lbl
@@ -2040,9 +2040,9 @@ def interact_gridsearch_result_images(show_result_func, cfgdict_list,
     assert callable(show_result_func), 'NEED FUNCTION GOT: %r' % (show_result_func,)
 
     import utool as ut
-    import ibeis.plottool as pt
-    from ibeis.plottool import plot_helpers as ph
-    from ibeis.plottool import interact_helpers as ih
+    import wbia.plottool as pt
+    from wbia.plottool import plot_helpers as ph
+    from wbia.plottool import interact_helpers as ih
     if verbose:
         print('Plotting gridsearch results figtitle=%r' % (figtitle,))
     if score_list is None:
@@ -2128,8 +2128,8 @@ def gridsearch_timer(func_list, args_list, niters=None, **searchkw):
     unpacked
 
     CommandLine:
-        python -m ibeis.annotmatch_funcs --exec-get_annotmatch_rowids_from_aid2 --show
-        python -m ibeis.annotmatch_funcs --exec-get_annotmatch_rowids_from_aid:1 --show
+        python -m wbia.annotmatch_funcs --exec-get_annotmatch_rowids_from_aid2 --show
+        python -m wbia.annotmatch_funcs --exec-get_annotmatch_rowids_from_aid:1 --show
 
     Args:
         func_list (list):
@@ -2208,7 +2208,7 @@ def gridsearch_timer(func_list, args_list, niters=None, **searchkw):
     xtick_list = [count_to_xtick(count, get_args(count)) for count in count_list]
 
     def plot_timings():
-        import ibeis.plottool as pt
+        import wbia.plottool as pt
         ydata_list = ut.dict_take(timings, func_list)
         xdata = xtick_list
 

--- a/utool/util_import.py
+++ b/utool/util_import.py
@@ -208,9 +208,9 @@ def package_contents(package, with_pkg=False, with_mod=True, ignore_prefix=[],
         >>> # DISABLE_DOCTEST
         >>> from utool.util_import import *  # NOQA
         >>> import utool as ut
-        >>> import ibeis
+        >>> import wbia
         >>> package = ibeis
-        >>> ignore_prefix = ['ibeis.tests', 'ibeis.control.__SQLITE3__',
+        >>> ignore_prefix = ['wbia.tests', 'wbia.control.__SQLITE3__',
         >>>                  '_autogen_explicit_controller']
         >>> ignore_suffix = ['_grave']
         >>> with_pkg = False
@@ -286,7 +286,7 @@ def check_module_installed(modname):
 
     CommandLine:
         python -m utool.util_import check_module_installed --show --verbimp --modname=this
-        python -m utool.util_import check_module_installed --show --verbimp --modname=ibeis.scripts.iccv
+        python -m utool.util_import check_module_installed --show --verbimp --modname=wbia.scripts.iccv
 
     Example:
         >>> # ENABLE_DOCTEST

--- a/utool/util_inspect.py
+++ b/utool/util_inspect.py
@@ -169,7 +169,7 @@ def get_internal_call_graph(fpath, with_doctests=False):
         >>> with_doctests = ut.get_argflag('--with_doctests')
         >>> G = get_internal_call_graph(fpath, with_doctests)
         >>> ut.quit_if_noshow()
-        >>> import ibeis.plottool as pt
+        >>> import wbia.plottool as pt
         >>> pt.qt4ensure()
         >>> pt.show_nx(G, fontsize=8, as_directed=False)
         >>> z = pt.zoom_factory()
@@ -474,7 +474,7 @@ def check_module_usage(modpath_patterns):
     # import copy
     # func_call_graph2 = copy.deepcopy(func_numcall_graph)
     # #ignore_modnames = []
-    # ignore_modnames = ['ibeis.algo.hots.multi_index', 'ibeis.algo.hots._neighbor_experiment']
+    # ignore_modnames = ['wbia.algo.hots.multi_index', 'wbia.algo.hots._neighbor_experiment']
     # num_callers = ut.ddict(dict)
     # for modname, modpath in list(zip(modnames, modpaths)):
     #     subdict = func_call_graph2[modname]
@@ -624,11 +624,11 @@ def get_dev_hints():
 
     registered_hints = OrderedDict([
         # General IBEIS hints
-        ('ibs.*'   , ('ibeis.IBEISController', 'image analysis api')),
-        ('testres', ('ibeis.TestResult', 'test result object')),
-        ('qreq_'   , ('ibeis.QueryRequest', 'query request object with hyper-parameters')),
-        ('cm'  , ('ibeis.ChipMatch', 'object of feature correspondences and scores')),
-        ('qparams*', ('ibeis.QueryParams', 'query hyper-parameters')),
+        ('ibs.*'   , ('wbia.IBEISController', 'image analysis api')),
+        ('testres', ('wbia.TestResult', 'test result object')),
+        ('qreq_'   , ('wbia.QueryRequest', 'query request object with hyper-parameters')),
+        ('cm'  , ('wbia.ChipMatch', 'object of feature correspondences and scores')),
+        ('qparams*', ('wbia.QueryParams', 'query hyper-parameters')),
         ('qaid2_cm.*'   , ('dict', 'dict of ``ChipMatch`` objects')),
         ('vecs'    , ('ndarray[uint8_t, ndim=2]', 'descriptor vectors')),
         ('maws'    , ('ndarray[float32_t, ndim=1]', 'multiple assignment weights')),
@@ -794,7 +794,7 @@ def infer_arg_types_and_descriptions(argname_list, defaults):
         python -m utool.util_inspect --test-infer_arg_types_and_descriptions
 
     Ignore:
-        python -c "import utool; print(utool.auto_docstr('ibeis.algo.hots.pipeline', 'build_chipmatches'))"
+        python -c "import utool; print(utool.auto_docstr('wbia.algo.hots.pipeline', 'build_chipmatches'))"
 
     Example:
         >>> # ENABLE_DOCTEST
@@ -911,19 +911,19 @@ def iter_module_doctestable(module, include_funcs=True, include_classes=True,
 
     CommandLine:
         python -m utool --tf iter_module_doctestable \
-            --modname=ibeis.algo.hots.chip_match
-            --modname=ibeis.control.IBEISControl
-            --modname=ibeis.control.SQLDatabaseControl
-            --modname=ibeis.control.manual_annot_funcs
-            --modname=ibeis.control.manual_annot_funcs
-            --modname=ibeis.expt.test_result
+            --modname=wbia.algo.hots.chip_match
+            --modname=wbia.control.IBEISControl
+            --modname=wbia.control.SQLDatabaseControl
+            --modname=wbia.control.manual_annot_funcs
+            --modname=wbia.control.manual_annot_funcs
+            --modname=wbia.expt.test_result
             --modname=utool.util_progress --debug-key=build_msg_fmtstr_time2
             --modname=utool.util_progress --debug-key=ProgressIter
 
     Debug:
        # fix profile with doctest
        utprof.py -m utool --tf iter_module_doctestable --modname=utool.util_inspect --debugkey=zzz_profiled_is_yes
-       utprof.py -m utool --tf iter_module_doctestable --modname=ibeis.algo.hots.chip_match --debugkey=to_json
+       utprof.py -m utool --tf iter_module_doctestable --modname=wbia.algo.hots.chip_match --debugkey=to_json
 
     Example1:
         >>> # ENABLE_DOCTEST
@@ -2223,7 +2223,7 @@ def execstr_func_doctest(func, num=0, start_sentinal=None, end_sentinal=None):
 
     func = encoder.learn_threshold2
     num = 0
-    start_sentinal = 'import ibeis.plottool as pt'
+    start_sentinal = 'import wbia.plottool as pt'
     end_sentinal = 'pnum_ = pt.make_pnum_nextgen'
     """
     import utool as ut
@@ -2247,7 +2247,7 @@ def exec_func_doctest(func, start_sentinal=None, end_sentinal=None, num=0, globa
 
     func = encoder.learn_threshold2
     num = 0
-    start_sentinal = 'import ibeis.plottool as pt'
+    start_sentinal = 'import wbia.plottool as pt'
     end_sentinal = 'pnum_ = pt.make_pnum_nextgen'
     """
     import utool as ut
@@ -2562,8 +2562,8 @@ def recursive_parse_kwargs(root_func, path_=None, verbose=None):
 
         python -m utool.util_inspect recursive_parse_kwargs:2 --mod vtool --func ScoreNormalizer.visualize
 
-        python -m utool.util_inspect recursive_parse_kwargs:2 --mod ibeis.viz.viz_matches --func show_name_matches --verbinspect
-        python -m utool.util_inspect recursive_parse_kwargs:2 --mod ibeis.expt.experiment_drawing --func draw_rank_cmc --verbinspect
+        python -m utool.util_inspect recursive_parse_kwargs:2 --mod wbia.viz.viz_matches --func show_name_matches --verbinspect
+        python -m utool.util_inspect recursive_parse_kwargs:2 --mod wbia.expt.experiment_drawing --func draw_rank_cmc --verbinspect
 
     Example:
         >>> # ENABLE_DOCTEST
@@ -2585,14 +2585,14 @@ def recursive_parse_kwargs(root_func, path_=None, verbose=None):
     Example:
         >>> # xdoctest: +REQUIRES(module:ibeis)
         >>> from utool.util_inspect import *  # NOQA
-        >>> from ibeis.algo.hots import chip_match
+        >>> from wbia.algo.hots import chip_match
         >>> import utool as ut
         >>> recursive_parse_kwargs(chip_match.ChipMatch.show_ranked_matches)
         >>> recursive_parse_kwargs(chip_match.ChipMatch)
 
-        import ibeis
+        import wbia
         import utool as ut
-        ibs = ibeis.opendb(defaultdb='testdb1')
+        ibs = wbia.opendb(defaultdb='testdb1')
         kwkeys1 = ibs.parse_annot_stats_filter_kws()
         ut.recursive_parse_kwargs(ibs.get_annotconfig_stats, verbose=1)
         kwkeys2 = list(ut.recursive_parse_kwargs(ibs.get_annotconfig_stats).keys())
@@ -2652,7 +2652,7 @@ def recursive_parse_kwargs(root_func, path_=None, verbose=None):
         if attr == 'ut':
             subdict = ut.__dict__
         elif attr == 'pt':
-            import ibeis.plottool as pt
+            import wbia.plottool as pt
             subdict = pt.__dict__
         else:
             subdict = None
@@ -2763,7 +2763,7 @@ def parse_func_kwarg_keys(func, with_vals=False):
 
 def get_func_kwargs(func, recursive=True):
     """
-    func = ibeis.run_experiment
+    func = wbia.run_experiment
 
     SeeAlso:
         argparse_funckw

--- a/utool/util_ipynb.py
+++ b/utool/util_ipynb.py
@@ -197,11 +197,11 @@ def code_cell(sourcecode):
         str: json formatted ipython notebook code cell
 
     CommandLine:
-        python -m ibeis.templates.generate_notebook --exec-code_cell
+        python -m wbia.templates.generate_notebook --exec-code_cell
 
     Example:
         >>> # DISABLE_DOCTEST
-        >>> from ibeis.templates.generate_notebook import *  # NOQA
+        >>> from wbia.templates.generate_notebook import *  # NOQA
         >>> sourcecode = notebook_cells.timestamp_distribution[1]
         >>> sourcecode = notebook_cells.initialize[1]
         >>> result = code_cell(sourcecode)
@@ -246,11 +246,11 @@ def markdown_cell(markdown):
         str: json formatted ipython notebook markdown cell
 
     CommandLine:
-        python -m ibeis.templates.generate_notebook --exec-markdown_cell
+        python -m wbia.templates.generate_notebook --exec-markdown_cell
 
     Example:
         >>> # DISABLE_DOCTEST
-        >>> from ibeis.templates.generate_notebook import *  # NOQA
+        >>> from wbia.templates.generate_notebook import *  # NOQA
         >>> markdown = '# Title'
         >>> result = markdown_cell(markdown)
         >>> print(result)
@@ -336,11 +336,11 @@ def repr_single_for_md(s):
         str: str_repr
 
     CommandLine:
-        python -m ibeis.templates.generate_notebook --exec-repr_single_for_md --show
+        python -m wbia.templates.generate_notebook --exec-repr_single_for_md --show
 
     Example:
         >>> # DISABLE_DOCTEST
-        >>> from ibeis.templates.generate_notebook import *  # NOQA
+        >>> from wbia.templates.generate_notebook import *  # NOQA
         >>> s = '#HTML(\'<iframe src="%s" width=700 height=350></iframe>\' % pdf_fpath)'
         >>> result = repr_single_for_md(s)
         >>> print(result)

--- a/utool/util_parallel.py
+++ b/utool/util_parallel.py
@@ -135,8 +135,8 @@ def generate2(func, args_gen, kw_gen=None, ntasks=None, ordered=True,
         >>> except ImportError:
         >>>     import vtool as vt
         >>> import utool as ut
-        >>> from ibeis.algo.preproc.preproc_chip import gen_chip
-        >>> #from ibeis.algo.preproc.preproc_feat import gen_feat_worker
+        >>> from wbia.algo.preproc.preproc_chip import gen_chip
+        >>> #from wbia.algo.preproc.preproc_feat import gen_feat_worker
         >>> key_list = ['grace.jpg', 'easy1.png', 'ada2.jpg', 'easy3.png',
         >>>             'hard3.png', 'zebra.png', 'patsy.jpg', 'ada.jpg',
         >>>             'carl.jpg', 'lena.png', 'easy2.png']
@@ -162,7 +162,7 @@ def generate2(func, args_gen, kw_gen=None, ntasks=None, ordered=True,
         >>> except ImportError:
         >>>     import vtool as vt
         >>> import utool as ut
-        >>> from ibeis.algo.preproc.preproc_chip import gen_chip
+        >>> from wbia.algo.preproc.preproc_chip import gen_chip
         >>> import cv2
         >>> from utool.util_parallel import __testwarp
         >>> key_list = ['grace.jpg', 'easy1.png', 'ada2.jpg', 'easy3.png',

--- a/utool/util_scripts/check_jedi.py
+++ b/utool/util_scripts/check_jedi.py
@@ -19,7 +19,7 @@ def check_jedi_can_read_googlestyle():
         def spam(ibs, bar):
             r"""
             Args:
-                ibs (ibeis.IBEISController): an object
+                ibs (wbia.IBEISController): an object
             """
             import jedi
             jedi.n
@@ -38,7 +38,7 @@ def check_jedi_can_read_googlestyle():
     vartype = script.goto_definitions()
     print('vartype = %r' % (vartype,))
 
-    print('\n---testing jedi with ibeis.IBEISController')
+    print('\n---testing jedi with wbia.IBEISController')
     script = jedi.Script(source2, line=10)
     script.completions()
     # Find the variable type of argument
@@ -66,7 +66,7 @@ def _insource_jedi_vim_test(data, ibs):
 
     Args:
         data (utool.ColumnLists): a column list objct
-        ibs (ibeis.IBEISController): an object
+        ibs (wbia.IBEISController): an object
     """
     # TESTME: type a dot and tab. Hopefully autocomplete will happen.
     data
@@ -74,8 +74,8 @@ def _insource_jedi_vim_test(data, ibs):
     import utool as ut
     xdata = ut.ColumnLists()
     xdata
-    import ibeis
-    xibs = ibeis.IBEISController()
+    import wbia
+    xibs = wbia.IBEISController()
     xibs
 
 

--- a/utool/util_scripts/classfuncs.py
+++ b/utool/util_scripts/classfuncs.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
         'https://github.com/bluemellophone/detecttools.git',
         'https://github.com/Erotemic/hesaff.git',
         'https://github.com/bluemellophone/pyrf.git',
-        'https://github.com/Erotemic/ibeis.git',
+        'https://github.com/Erotemic/wbia.git',
         'https://github.com/aweinstock314/cyth.git',
         #'https://github.com/hjweide/pygist',
     ], code_dir=CODE_DIR)

--- a/utool/util_scripts/ensure_python3_compatible.py
+++ b/utool/util_scripts/ensure_python3_compatible.py
@@ -47,7 +47,7 @@ if 'CODE_DIR' in os.environ:
     'https://github.com/bluemellophone/detecttools.git',
     'https://github.com/Erotemic/hesaff.git',
     'https://github.com/bluemellophone/pyrf.git',
-    'https://github.com/Erotemic/ibeis.git',
+    'https://github.com/Erotemic/wbia.git',
     # 'https://github.com/aweinstock314/cyth.git',
     #'https://github.com/hjweide/pygist',
 ], CODE_DIR, forcessh=False)
@@ -59,9 +59,9 @@ ut.set_project_repos(IBEIS_REPO_URLS, IBEIS_REPO_DIRS)
 
 def ensure_ibeis_control_explicit_namespace(varname_list):
     # <input>
-    import ibeis
+    import wbia
     namespace = 'const'
-    module = ibeis.control.IBEISControl
+    module = wbia.control.IBEISControl
     fpath = module.__file__
     # </input>
     varname_list = [

--- a/utool/util_sqlite.py
+++ b/utool/util_sqlite.py
@@ -36,16 +36,16 @@ def get_table_csv(cur, tablename, exclude_columns=[]):
         str: csv_table
 
     CommandLine:
-        python -m ibeis.control.SQLDatabaseControl --test-get_table_csv
+        python -m wbia.control.SQLDatabaseControl --test-get_table_csv
 
     Example:
         >>> # DISABLE_DOCTEST
-        >>> from ibeis.control.SQLDatabaseControl import *  # NOQA
+        >>> from wbia.control.SQLDatabaseControl import *  # NOQA
         >>> # build test data
-        >>> import ibeis
-        >>> ibs = ibeis.opendb('testdb1')
+        >>> import wbia
+        >>> ibs = wbia.opendb('testdb1')
         >>> db = ibs.db
-        >>> tablename = ibeis.const.NAME_TABLE
+        >>> tablename = wbia.const.NAME_TABLE
         >>> exclude_columns = []
         >>> # execute function
         >>> csv_table = db.get_table_csv(tablename, exclude_columns)

--- a/utool/util_tests.py
+++ b/utool/util_tests.py
@@ -303,7 +303,7 @@ def doctest_funcs(testable_list=None, check_flags=True, module=None,
         tuple: (nPass, nTotal, failed_cmd_list)
 
     CommandLine:
-        python -m ibeis.algo.preproc.preproc_chip --all-examples
+        python -m wbia.algo.preproc.preproc_chip --all-examples
 
     References:
         http://legacy.python.org/dev/peps/pep-0338/
@@ -1168,8 +1168,8 @@ def get_doctest_examples(func_or_class, modpath=None):
     Example2:
         >>> # DISABLE_DOCTEST
         >>> from utool.util_tests import *  # NOQA
-        >>> import ibeis
-        >>> func_or_class = ibeis.control.manual_annot_funcs.add_annots
+        >>> import wbia
+        >>> func_or_class = wbia.control.manual_annot_funcs.add_annots
         >>> tup = get_doctest_examples(func_or_class)
         >>> testsrc_list, testwant_list, testlinenum_list, func_lineno, docstr = tup
         >>> result = str(len(testsrc_list) + len(testwant_list))
@@ -1782,7 +1782,7 @@ def show_was_requested():
     IPython (and presumably want some sort of interaction
     """
     try:
-        import ibeis.plottool as pt
+        import wbia.plottool as pt
     except ImportError:
         import plottool as pt
     return pt.show_was_requested()
@@ -1803,7 +1803,7 @@ except ImportError:
 
 def qt4ensure():
     try:
-        import ibeis.plottool as pt
+        import wbia.plottool as pt
     except ImportError:
         import plottool as pt
     pt.qtensure()
@@ -1811,7 +1811,7 @@ def qt4ensure():
 
 def qtensure():
     try:
-        import ibeis.plottool as pt
+        import wbia.plottool as pt
     except ImportError:
         import plottool as pt
     pt.qtensure()
@@ -1826,7 +1826,7 @@ def quit_if_noshow():
 
 def show_if_requested():
     try:
-        import ibeis.plottool as pt
+        import wbia.plottool as pt
     except ImportError:
         import plottool as pt
     pt.show_if_requested(N=2)

--- a/utool/util_ubuntu.py
+++ b/utool/util_ubuntu.py
@@ -303,7 +303,7 @@ class XCtrl(object):
         """
         import utool as ut
         try:
-            import ibeis.plottool.screeninfo as screeninfo
+            import wbia.plottool.screeninfo as screeninfo
         except ImportError:
             import plottool.screeninfo as screeninfo
         monitor_infos = {


### PR DESCRIPTION
We are in the middle of renaming our repos from ibeis to wbia.

The changes are from running this command:

```
git grep -l ibeis utool | xargs sed -i \
    -e 's/\(from\|import\) ibeis\(\.\| \|$\)/\1 wbia\2/g' \
    -e 's/\(from\|import\) guitool_ibeis/\1 ibeis.guitool/g' \
    -e 's/\([^_]\)ibeis\./\1wbia./g'
```

and manually changing 2 instances of `guitool_ibeis` to `wbia.guitool`
in utool/Preferences.py

It seems we forgot to rename `guitool_ibeis` to `ibeis.guitool`, so just
skip that step and rename `guitool_ibeis` to `wbia.guitool`.