### PR TITLE
Rename vtool_ibeis import references to vtool

### DIFF
--- a/utool/util_alg.py
+++ b/utool/util_alg.py
@@ -1774,7 +1774,7 @@ def maximin_distance_subset1d(items, K=None, min_thresh=None, verbose=False):
 
     import utool as ut
     try:
-        import vtool_ibeis as vt
+        import vtool as vt
     except ImportError:
         import vtool as vt
     points = np.array(items)[:, None]
@@ -2063,7 +2063,7 @@ def safe_pdist(arr, *args, **kwargs):
         return None
     else:
         try:
-            import vtool_ibeis as vt
+            import vtool as vt
         except ImportError:
             import vtool as vt
 

--- a/utool/util_dev.py
+++ b/utool/util_dev.py
@@ -2170,7 +2170,7 @@ def inverable_group_multi_list(item_lists):
     """
     #unique_list1, inverse1 = np.unique(item1_list, return_index=True, return_inverse=True)
     try:
-        import vtool_ibeis as vt
+        import vtool as vt
     except ImportError:
         import vtool as vt
     import utool as ut

--- a/utool/util_graph.py
+++ b/utool/util_graph.py
@@ -1931,7 +1931,7 @@ def graph_info(graph, ignore=None, stats=False, verbose=False):
 def get_graph_bounding_box(graph):
     # import utool as ut
     try:
-        import vtool_ibeis as vt
+        import vtool as vt
     except ImportError:
         import vtool as vt
     #nx.get_node_attrs = nx.get_node_attributes

--- a/utool/util_latex.py
+++ b/utool/util_latex.py
@@ -275,7 +275,7 @@ def render_latex(input_text, dpath=None, fname=None, preamb_extra=None,
     """
     import utool as ut
     try:
-        import vtool_ibeis as vt
+        import vtool as vt
     except ImportError:
         import vtool as vt
     # turn off page numbers

--- a/utool/util_parallel.py
+++ b/utool/util_parallel.py
@@ -131,7 +131,7 @@ def generate2(func, args_gen, kw_gen=None, ntasks=None, ordered=True,
         >>> # UNSTABLE_DOCTEST
         >>> # Trying to recreate the freeze seen in IBEIS
         >>> try:
-        >>>     import vtool_ibeis as vt
+        >>>     import vtool as vt
         >>> except ImportError:
         >>>     import vtool as vt
         >>> import utool as ut
@@ -158,7 +158,7 @@ def generate2(func, args_gen, kw_gen=None, ntasks=None, ordered=True,
         >>> # Extremely weird case: freezes only if dsize > (313, 313) AND __testwarp was called beforehand.
         >>> # otherwise the parallel loop works fine. Could be an opencv 3.0.0-dev issue.
         >>> try:
-        >>>     import vtool_ibeis as vt
+        >>>     import vtool as vt
         >>> except ImportError:
         >>>     import vtool as vt
         >>> import utool as ut
@@ -359,7 +359,7 @@ def __testwarp(tup):
     import cv2
     import numpy as np
     try:
-        import vtool_ibeis as vt
+        import vtool as vt
     except ImportError:
         import vtool as vt
     img = tup[0]
@@ -445,7 +445,7 @@ def _test_buffered_generator3():
         >>> _test_buffered_generator3()
     """
     try:
-        import vtool_ibeis as vt
+        import vtool as vt
     except ImportError:
         import vtool as vt
     import utool as ut
@@ -617,7 +617,7 @@ def bgfunc(path):
     # Test for /_test_buffered_generator_img
     #import utool as ut
     try:
-        import vtool_ibeis as vt
+        import vtool as vt
     except ImportError:
         import vtool as vt
     for _ in range(1):


### PR DESCRIPTION
We renamed vtool_ibeis to vtool in the wbia-vtool repo.

```
git grep -l vtool_ibeis | xargs sed -i 's/vtool_ibeis/vtool/g'
```