### PR TITLE
Fix scipy.misc.comb imports, custom unpickler to handle renamed modules

### DIFF
--- a/autogen_test_script.py
+++ b/autogen_test_script.py
@@ -294,26 +294,26 @@ def make_run_tests_script_text(test_headers, test_argvs, quick_tests=None,
     return script_text
 
 
-def autogen_ibeis_runtest():
+def autogen_wbia_runtest():
     """ special case to generate tests script for IBEIS
 
     Example:
         >>> # DISABLE_DOCTEST
         >>> from autogen_test_script import *  # NOQA
-        >>> test_script = autogen_ibeis_runtest()
+        >>> test_script = autogen_wbia_runtest()
         >>> print(test_script)
 
     CommandLine:
-        python -c "import utool; utool.autogen_ibeis_runtest()"
-        python -c "import utool; print(utool.autogen_ibeis_runtest())"
+        python -c "import utool; utool.autogen_wbia_runtest()"
+        python -c "import utool; print(utool.autogen_wbia_runtest())"
 
-        python -c "import utool; print(utool.autogen_ibeis_runtest())" > run_tests.sh
+        python -c "import utool; print(utool.autogen_wbia_runtest())" > run_tests.sh
         chmod +x run_tests.sh
 
     """
 
     quick_tests = [
-        'ibeis/tests/assert_modules.py'
+        'wbia/tests/assert_modules.py'
     ]
 
     #test_pattern = [
@@ -415,7 +415,7 @@ if __name__ == '__main__':
         python autogen_test_script.py
         python autogen_test_script.py -w
     """
-    shscript_text, pyscript_text = autogen_ibeis_runtest()
+    shscript_text, pyscript_text = autogen_wbia_runtest()
     runtest_fname = None
 
     if runtest_fname is None and ut.get_argflag('-w'):

--- a/publish.sh
+++ b/publish.sh
@@ -45,7 +45,7 @@ Usage:
 
     echo "MB_PYTHON_TAG = $MB_PYTHON_TAG"
     MB_PYTHON_TAG=$MB_PYTHON_TAG ./run_multibuild.sh
-    DEPLOY_BRANCH=master DEPLOY_REMOTE=ibeis MB_PYTHON_TAG=$MB_PYTHON_TAG ./publish.sh yes
+    DEPLOY_BRANCH=master DEPLOY_REMOTE=wbia MB_PYTHON_TAG=$MB_PYTHON_TAG ./publish.sh yes
 
     MB_PYTHON_TAG=py2.py3-none-any ./publish.sh
 '''

--- a/utool/Preferences.py
+++ b/utool/Preferences.py
@@ -313,7 +313,7 @@ class Pref(PrefNode):
                                   iswarning=True)
                 raise AttributeError(
                     ('Pref object is missing named attribute: name=%r.'
-                     'You might try running ibeis with --nocache-pref '
+                     'You might try running wbia with --nocache-pref '
                      'to see if that fixes things.')  % name)
                 #raise
 
@@ -598,7 +598,7 @@ def test_Preferences():
 
     Example:
         >>> # DISABLE_DOCTEST
-        >>> # xdoctest: +REQUIRES(module:guitool_ibeis)
+        >>> # xdoctest: +REQUIRES(module:wbia.guitool)
         >>> # FIXME depends on guitool_ibei
         >>> from utool.Preferences import *  # NOQA
         >>> import utool as ut

--- a/utool/__init__.py
+++ b/utool/__init__.py
@@ -777,7 +777,7 @@ if DOELSE:
     from utool.util_project import (GrepResult, SetupRepo, UserProfile,
                                     ensure_text, ensure_user_profile,
                                     glob_projects, grep_projects,
-                                    ibeis_user_profile, sed_projects,
+                                    wbia_user_profile, sed_projects,
                                     setup_repo,)
     from utool.util_parallel import (KillableProcess, KillableThread, bgfunc,
                                      buffered_generator, generate2,

--- a/utool/experimental/euler_tour_tree_avl.py
+++ b/utool/experimental/euler_tour_tree_avl.py
@@ -433,7 +433,7 @@ class EulerTourTree(ut.NiceRepr):
         return repr_tree
 
     def show_nx(self, labels=['value'], edge_labels=False, fnum=None):
-        import plottool as pt
+        import wbia.plottool as pt
         graph = self.to_networkx(labels=labels, edge_labels=edge_labels)
         pt.show_nx(graph, fnum=fnum)
 

--- a/utool/oldalg.py
+++ b/utool/oldalg.py
@@ -364,7 +364,7 @@ def bayesnet():
 
     # _ draw model
 
-    import plottool as pt
+    import wbia.plottool as pt
     import networkx as netx
     fig = pt.figure()  # NOQA
     fig.clf()

--- a/utool/util_alg.py
+++ b/utool/util_alg.py
@@ -1090,7 +1090,7 @@ def get_nth_prime_bruteforce(n, start_guess=2, start_num_primes=0):
         >>>     time_list += [t.ellapsed]
         >>>     n_list += [n]
         >>> ut.quit_if_noshow()
-        >>> import plottool as pt
+        >>> import wbia.plottool as pt
         >>> pt.multi_plot(n_list, [time_list], xlabel='prime', ylabel='time')
         >>> ut.show_if_requested()
     """
@@ -2039,7 +2039,7 @@ def unixtime_hourdiff(x, y):
         >>> result = unixtime_hourdiff(x, y)
         >>> print(result)
         >>> ut.quit_if_noshow()
-        >>> import plottool as pt
+        >>> import wbia.plottool as pt
         >>> ut.show_if_requested()
     """
     return np.abs((x - y)) / (60. ** 2)
@@ -2775,7 +2775,7 @@ def expensive_task_gen(num=8700):
         >>>     time_list = list(ut.expensive_task_gen(num))
         >>> print(sum(time_list))
         >>> ut.quit_if_noshow()
-        >>> import plottool as pt
+        >>> import wbia.plottool as pt
         >>> #pt.plot(time_list)
         >>> from scipy.optimize import curve_fit
         >>> def func(x, a, b, c, d):

--- a/utool/util_alg.py
+++ b/utool/util_alg.py
@@ -1657,8 +1657,8 @@ def choose(n, k):
     binomial combination (without replacement)
     scipy.special.binom
     """
-    import scipy.misc
-    return scipy.misc.comb(n, k, exact=True, repetition=False)
+    import scipy.special
+    return scipy.special.comb(n, k, exact=True, repetition=False)
 
 
 def triangular_number(n):

--- a/utool/util_autogen.py
+++ b/utool/util_autogen.py
@@ -617,18 +617,18 @@ def make_example_docstr(funcname=None, modname=None, argname_list=None,
         'rng'       : 'np.random.RandomState(0)',
     }
     import_depends_map = {
-        'ibeis':    'import ibeis',
+        'wbia':    'import wbia',
         'vt':       'import vtool as vt',
         #'img':      'import vtool as vt',  # TODO: remove. fix dependency
-        #'species':  'import ibeis',
+        #'species':  'import wbia',
     }
     var_depends_map = {
-        'species':   ['ibeis'],
-        'ibs':       ['ibeis'],
-        'testres': ['ibeis'],
+        'species':   ['wbia'],
+        'ibs':       ['wbia'],
+        'testres': ['wbia'],
         'kpts':      ['vt'],
         #'qreq_':     ['ibs', 'species', 'daids', 'qaids'],
-        'qreq_':     ['ibeis'],
+        'qreq_':     ['wbia'],
         'qaids':     ['ibs'],
         'daids':     ['ibs'],
         'qaids':     ['species'],
@@ -1040,7 +1040,7 @@ def find_modname_in_pythonpath(modname):
 if __name__ == '__main__':
     """
     CommandLine:
-        python ibeis/control/template_generator.py --tbls annotations --Tflags getters native
+        python wbia/control/template_generator.py --tbls annotations --Tflags getters native
         python -c "import utool, utool.util_autogen; utool.doctest_funcs(utool.util_autogen, allexamples=True)"
         python -m utool.util_autogen
         python -m utool.util_autogen --allexamples

--- a/utool/util_cache.py
+++ b/utool/util_cache.py
@@ -184,13 +184,13 @@ def _args2_fpath(dpath, fname, cfgstr, ext):
         >>> from utool.util_cache import *  # NOQA
         >>> from utool.util_cache import _args2_fpath
         >>> import utool as ut
-        >>> dpath = 'F:\\data\\work\\PZ_MTEST\\_ibsdb\\_ibeis_cache'
+        >>> dpath = 'F:\\data\\work\\PZ_MTEST\\_ibsdb\\_wbia_cache'
         >>> fname = 'normalizer_'
         >>> cfgstr = u'PZ_MTEST_DSUUIDS((9)67j%dr%&bl%4oh4+)_QSUUIDS((9)67j%dr%&bl%4oh4+)zebra_plains_vsone_NN(single,K1+1,last,cks1024)_FILT(ratio<0.625;1.0,fg;1.0)_SV(0.01;2;1.57minIn=4,nRR=50,nsum,)_AGG(nsum)_FLANN(4_kdtrees)_FEATWEIGHT(ON,uselabel,rf)_FEAT(hesaff+sift_)_CHIP(sz450)'
         >>> ext = '.cPkl'
         >>> fpath = _args2_fpath(dpath, fname, cfgstr, ext)
         >>> result = str(ut.ensure_unixslash(fpath))
-        >>> target = 'F:/data/work/PZ_MTEST/_ibsdb/_ibeis_cache/normalizer_xfylfboirymmcpfg.cPkl'
+        >>> target = 'F:/data/work/PZ_MTEST/_ibsdb/_wbia_cache/normalizer_xfylfboirymmcpfg.cPkl'
         >>> ut.assert_eq(result, target)
 
     """

--- a/utool/util_config.py
+++ b/utool/util_config.py
@@ -45,7 +45,7 @@ def get_default_global_config():
 
             'joncrall': {'name': 'Jon Crall',
                          'email': 'erotemic@gmail.com',
-                         'permited repos': ['ibeis', 'utool', 'hesaff',
+                         'permited repos': ['wbia', 'utool', 'hesaff',
                                             'guitool', 'plottool', 'vtool'],
                          'aliases': [],
                          'machines': [], },

--- a/utool/util_dev.py
+++ b/utool/util_dev.py
@@ -327,7 +327,7 @@ def timeit_grid(stmt_list, setup='', iterations=10000, input_sizes=None,
         try:
             import wbia.plottool as pt
         except ImportError:
-            import plottool as pt
+            import wbia.plottool as pt
         color_list = pt.distinct_colors(len(stmt_list))
         for count, (stmt, color) in enumerate(zip(stmt_list, color_list)):
             pt.plot(input_sizes, time_grid.T[count], 'x-', color=color, label=stmt)
@@ -2090,7 +2090,7 @@ def iup():
     try:
         import wbia.plottool as pt
     except ImportError:
-        import plottool as pt
+        import wbia.plottool as pt
     pt.iup()
 
 
@@ -2356,7 +2356,7 @@ def pylab_qt4():
     try:
         import wbia.plottool as pt
     except ImportError:
-        import plottool as pt
+        import wbia.plottool as pt
     pt.ensureqt()
 
 
@@ -2364,7 +2364,7 @@ def ensureqt():
     try:
         import wbia.plottool as pt
     except ImportError:
-        import plottool as pt
+        import wbia.plottool as pt
     pt.ensureqt()
 
 

--- a/utool/util_git.py
+++ b/utool/util_git.py
@@ -811,7 +811,7 @@ class Repo(util_dev.NiceRepr):
             http://stackoverflow.com/questions/9524933/renaming-a-branch-in-github
 
         CommandLine:
-            python -m utool.util_git --test-rename_branch --old=mymaster --new=ibeis_master
+            python -m utool.util_git --test-rename_branch --old=mymaster --new=wbia_master
 
         Example:
             >>> # DISABLE_DOCTEST

--- a/utool/util_grabdata.py
+++ b/utool/util_grabdata.py
@@ -68,10 +68,10 @@ def archive_files(archive_fpath, fpath_list, small=True, allowZip64=False,
         # http://superuser.com/questions/281573/best-options-compressing-files-7-zip
         # Create a small 7zip archive
         7z a -t7z -m0=lzma -mx=9 -mfb=64 -md=32m -ms=on archive.7z dir1
-        7z a -t7z -m0=lzma -mx=9 -mfb=64 -md=32m -ms=on ibeis-linux-binary.7z ibeis
+        7z a -t7z -m0=lzma -mx=9 -mfb=64 -md=32m -ms=on wbia-linux-binary.7z wbia
 
         # Create a small zip archive
-        7za a -mm=Deflate -mfb=258 -mpass=15 -r ibeis-linux-binary.zip ibeis
+        7za a -mm=Deflate -mfb=258 -mpass=15 -r wbia-linux-binary.zip wbia
 
     """
     import utool as ut

--- a/utool/util_graph.py
+++ b/utool/util_graph.py
@@ -96,7 +96,7 @@ def nx_transitive_reduction(G, mode=1):
         >>> try:
         >>>     import wbia.plottool as pt
         >>> except ImportError:
-        >>>     import plottool as pt
+        >>>     import wbia.plottool as pt
         >>> G_ = nx.dag.transitive_closure(G)
         >>> pt.show_nx(G    , pnum=(1, 5, 1), fnum=1)
         >>> pt.show_nx(G_tr , pnum=(1, 5, 2), fnum=1)
@@ -251,7 +251,7 @@ def nx_dag_node_rank(graph, nodes=None):
     Ignore:
         simple_graph = ut.simplify_graph(exi_graph)
         adj_dict = ut.nx_to_adj_dict(simple_graph)
-        import plottool as pt
+        import wbia.plottool as pt
         pt.qt4ensure()
         pt.show_nx(graph)
 
@@ -1082,7 +1082,7 @@ def nx_ensure_agraph_color(graph):
         import wbia.plottool as pt
     except ImportError:
         from plottool import color_funcs
-        import plottool as pt
+        import wbia.plottool as pt
     #import six
     def _fix_agraph_color(data):
         try:
@@ -1157,7 +1157,7 @@ def testdata_graph():
         >>> from utool.util_graph import *  # NOQA
         >>> import utool as ut
         >>> (graph, G) = testdata_graph()
-        >>> import plottool as pt
+        >>> import wbia.plottool as pt
         >>> ut.ensureqt()
         >>> pt.show_nx(G, layout='agraph')
         >>> ut.show_if_requested()
@@ -1838,7 +1838,7 @@ def color_nodes(graph, labelattr='label', brightness=.878,
     try:
         import wbia.plottool as pt
     except ImportError:
-        import plottool as pt
+        import wbia.plottool as pt
     import utool as ut
     node_to_lbl = nx.get_node_attributes(graph, labelattr)
     unique_lbls = sorted(set(node_to_lbl.values()))
@@ -2068,7 +2068,7 @@ def approx_min_num_components(nodes, negative_edges):
         >>> g_pos = nx.Graph()
         >>> g_pos.add_edges_from(edges)
         >>> g_neg = nx.complement(g_pos)
-        >>> #import plottool as pt
+        >>> #import wbia.plottool as pt
         >>> #pt.qt4ensure()
         >>> #pt.show_nx(g_pos)
         >>> #pt.show_nx(g_neg)

--- a/utool/util_gridsearch.py
+++ b/utool/util_gridsearch.py
@@ -29,7 +29,7 @@ class CountstrParser(object):
     Parses a statement like  '#primary>0&#primary1>1' and returns a filtered
     set.
 
-    FIXME: make generalizable beyond ibeis
+    FIXME: make generalizable beyond wbia
     """
     numop = '#'
     compare_op_map = {

--- a/utool/util_import.py
+++ b/utool/util_import.py
@@ -209,7 +209,7 @@ def package_contents(package, with_pkg=False, with_mod=True, ignore_prefix=[],
         >>> from utool.util_import import *  # NOQA
         >>> import utool as ut
         >>> import wbia
-        >>> package = ibeis
+        >>> package = wbia
         >>> ignore_prefix = ['wbia.tests', 'wbia.control.__SQLITE3__',
         >>>                  '_autogen_explicit_controller']
         >>> ignore_suffix = ['_grave']

--- a/utool/util_inspect.py
+++ b/utool/util_inspect.py
@@ -403,8 +403,8 @@ def check_module_usage(modpath_patterns):
             r'\-\-exec\-',
             r'\-\-test-',
             r'^\s*python -m ',
-            r'^\s*python -m ibeis ',
-            r'^\s*ibeis ',
+            r'^\s*python -m wbia ',
+            r'^\s*wbia ',
             r'\-\-test\-[a-zA-z]*\.',
             r'\-\-exec\-[a-zA-z]*\.',
         ]
@@ -2583,7 +2583,7 @@ def recursive_parse_kwargs(root_func, path_=None, verbose=None):
         ]
 
     Example:
-        >>> # xdoctest: +REQUIRES(module:ibeis)
+        >>> # xdoctest: +REQUIRES(module:wbia)
         >>> from utool.util_inspect import *  # NOQA
         >>> from wbia.algo.hots import chip_match
         >>> import utool as ut
@@ -3085,7 +3085,7 @@ def infer_function_info(func):
 
     CommandLine:
         python -m utool --tf infer_function_info:0
-        python -m utool --tf infer_function_info:1 --funcname=ibeis_cnn.models.siam.ignore_hardest_cases
+        python -m utool --tf infer_function_info:1 --funcname=wbia_cnn.models.siam.ignore_hardest_cases
 
     Ignore:
         >>> # ENABLE_DOCTEST

--- a/utool/util_io.py
+++ b/utool/util_io.py
@@ -256,6 +256,13 @@ def save_cPkl(fpath, data, verbose=None, n=None):
         pickle.dump(data, file_, protocol=2)
 
 
+class FixRenamedUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        module = module.replace('ibeis', 'wbia')
+        name = name.replace('ibeis', 'wbia')
+        return super(FixRenamedUnpickler, self).find_class(module, name)
+
+
 def load_cPkl(fpath, verbose=None, n=None):
     r"""
     Loads a pickled file with optional verbosity.
@@ -334,12 +341,12 @@ def load_cPkl(fpath, verbose=None, n=None):
         print('[util_io] * load_cPkl(%r)' % (util_path.tail(fpath, n=n),))
     try:
         with open(fpath, 'rb') as file_:
-            data = pickle.load(file_)
+            data = FixRenamedUnpickler(file_).load()
     except UnicodeDecodeError:
         if six.PY3:
             # try to open python2 pickle
             with open(fpath, 'rb') as file_:
-                data = pickle.load(file_, encoding='latin1')
+                data = FixRenamedUnpickler(file_, encoding='latin1').load()
         else:
             raise
     except ValueError as ex:

--- a/utool/util_iter.py
+++ b/utool/util_iter.py
@@ -609,13 +609,13 @@ def random_combinations(items, size, num=None, rng=None):
         >>> result = ('combos = %s' % (ut.repr2(combos),))
         >>> print(result)
     """
-    import scipy.misc
+    import scipy.special
     import numpy as np
     import utool as ut
     rng = ut.ensure_rng(rng, impl='python')
     num_ = np.inf if num is None else num
     # Ensure we dont request more than is possible
-    n_max = int(scipy.misc.comb(len(items), size))
+    n_max = int(scipy.special.comb(len(items), size))
     num_ = min(n_max, num_)
     if num is not None and num_ > n_max // 2:
         # If num is too big just generate all combinations and shuffle them

--- a/utool/util_list.py
+++ b/utool/util_list.py
@@ -3168,7 +3168,7 @@ def delete_list_items(list_, item_list, copy=False):
 
 def unflat_map(func, unflat_items, vectorized=False, **kwargs):
     r"""
-    Uses an ibeis lookup function with a non-flat rowid list.
+    Uses an wbia lookup function with a non-flat rowid list.
     In essence this is equivilent to [list(map(func, _items)) for _items in unflat_items].
     The utility of this function is that it only calls method once.
     This is more efficient for calls that can take a list of inputs

--- a/utool/util_project.py
+++ b/utool/util_project.py
@@ -148,7 +148,7 @@ def setup_repo():
         python -m utool setup_repo --repo=dtool --codedir=~/code
 
         python -m utool setup_repo --repo=dtool --codedir=~/code
-        python -m utool setup_repo --repo=ibeis-flukematch-module --codedir=~/code --modname=ibeis_flukematch
+        python -m utool setup_repo --repo=wbia-flukematch-module --codedir=~/code --modname=wbia_flukematch
         python -m utool setup_repo --repo=mtgmonte --codedir=~/code --modname=mtgmonte
         python -m utool setup_repo --repo=pydarknet --codedir=~/code --modname=pydarknet
         python -m utool setup_repo --repo=sandbox_utools --codedir=~/code --modname=sandbox_utools
@@ -536,7 +536,7 @@ class UserProfile(util_dev.NiceRepr):
     #     return
 
 
-def ibeis_user_profile():
+def wbia_user_profile():
     import utool as ut
     import sys
     addpath = True
@@ -545,7 +545,7 @@ def ibeis_user_profile():
         module_dpath = dirname(module_fpath)
         sys.path.append(module_dpath)
     REPOS1 = ut.import_module_from_fpath(module_fpath)
-    self = UserProfile(name='ibeis')
+    self = UserProfile(name='wbia')
     #self.project_dpaths = REPOS1.PROJECT_REPOS
     self.project_dpaths = REPOS1.IBEIS_REPOS
     # self.project_dpaths += [ut.truepath('~/latex/crall-candidacy-2015/')]
@@ -595,7 +595,7 @@ def ensure_user_profile(user_profile=None):
     if __GLOBAL_PROFILE__ is None:
         import utool as ut
         if ut.is_developer():
-            __GLOBAL_PROFILE__ = ibeis_user_profile()
+            __GLOBAL_PROFILE__ = wbia_user_profile()
         else:
             __GLOBAL_PROFILE__ = UserProfile('default')
     if user_profile is None:

--- a/utool/util_scripts/ensure_python3_compatible.py
+++ b/utool/util_scripts/ensure_python3_compatible.py
@@ -57,7 +57,7 @@ ut.set_code_dir(CODE_DIR)
 ut.set_project_repos(IBEIS_REPO_URLS, IBEIS_REPO_DIRS)
 
 
-def ensure_ibeis_control_explicit_namespace(varname_list):
+def ensure_wbia_control_explicit_namespace(varname_list):
     # <input>
     import wbia
     namespace = 'const'

--- a/utool/util_scripts/utoolwc.py
+++ b/utool/util_scripts/utoolwc.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import utool
 
-#def ibeis_wc():
+#def wbia_wc():
 
 
 if __name__ == '__main__':

--- a/utool/util_setup.py
+++ b/utool/util_setup.py
@@ -551,8 +551,8 @@ presetup = presetup_commands
 #     # from os.path import dirname, join
 #     import ast
 #     # repo_dpath = dirname(__file__)
-#     # file_fpath = join(repo_dpath, 'ibeis', '__init__.py')
-#     # file_fpath = join(repo_dpath, 'ibeis', 'control', 'DB_SCHEMA_CURRENT.py')
+#     # file_fpath = join(repo_dpath, 'wbia', '__init__.py')
+#     # file_fpath = join(repo_dpath, 'wbia', 'control', 'DB_SCHEMA_CURRENT.py')
 #     with open(fpath) as file_:
 #         sourcecode = file_.read()
 #     pt = ast.parse(sourcecode)

--- a/utool/util_str.py
+++ b/utool/util_str.py
@@ -349,7 +349,7 @@ def indent(str_, indent='    '):
 
 def indent_rest(str_, indent='    '):
     """ TODO fix name Indents every part of the string except the beginning
-    SeeAlso: ibeis/templates/generate_notebook.py
+    SeeAlso: wbia/templates/generate_notebook.py
     """
     return str_.replace('\n', '\n' + indent)
 
@@ -3081,7 +3081,7 @@ def testdata_text(num=1):
 
     text2 = ut.codeblock(r'''
         \begin{comment}
-        python -m ibeis -e rank_cmc -t invar -a viewdiff --test_cfgx_slice=6: --db PZ_Master1 --hargv=expt --prefix "Invariance+View Experiment "  # NOQA
+        python -m wbia -e rank_cmc -t invar -a viewdiff --test_cfgx_slice=6: --db PZ_Master1 --hargv=expt --prefix "Invariance+View Experiment "  # NOQA
         \end{comment}
         \ImageCommand{figuresX/expt_rank_cmc_PZ_Master1_a_viewdiff_t_invar.png}{\textwidth}{
         Results of the invariance experiment with different viewpoints for plains

--- a/utool/util_tests.py
+++ b/utool/util_tests.py
@@ -174,7 +174,7 @@ def get_package_testables(module=None, **tagkw):
         test_flags (None): (default = None)
 
     CommandLine:
-        python -m utool get_package_testables --show --mod ibeis
+        python -m utool get_package_testables --show --mod wbia
         python -m utool get_package_testables --show --mod utool --tags SCRIPT
         python -m utool get_package_testables --show --mod utool --tags ENABLE
 
@@ -1784,7 +1784,7 @@ def show_was_requested():
     try:
         import wbia.plottool as pt
     except ImportError:
-        import plottool as pt
+        import wbia.plottool as pt
     return pt.show_was_requested()
     #import utool as ut
     #return ut.get_argflag('--show') or ut.inIPython()
@@ -1805,7 +1805,7 @@ def qt4ensure():
     try:
         import wbia.plottool as pt
     except ImportError:
-        import plottool as pt
+        import wbia.plottool as pt
     pt.qtensure()
 
 
@@ -1813,7 +1813,7 @@ def qtensure():
     try:
         import wbia.plottool as pt
     except ImportError:
-        import plottool as pt
+        import wbia.plottool as pt
     pt.qtensure()
 
 
@@ -1828,7 +1828,7 @@ def show_if_requested():
     try:
         import wbia.plottool as pt
     except ImportError:
-        import plottool as pt
+        import wbia.plottool as pt
     pt.show_if_requested(N=2)
 
 
@@ -1900,8 +1900,8 @@ def get_module_completions(module):
 #    activate-global-python-argcomplete
 
 #    eval "$(register-python-argcomplete your_script)"
-#    register-python-argcomplete ibeis
-#    eval "$(register-python-argcomplete ibeis)"
+#    register-python-argcomplete wbia
+#    eval "$(register-python-argcomplete wbia)"
 #    """
 #    #if len(sys.argv) < 3:
 #    #    sys.exit(1)
@@ -1943,7 +1943,7 @@ def main_function_tester(module, ignore_prefix=[], ignore_suffix=[],
         testnames = get_module_completions(module)
         modname = module if isinstance(module, six.string_types) else module.__name__
         line = 'complete -W "%s" "%s"' % (' '.join(testnames), modname)
-        bash_completer = ut.unixjoin(ut.ensure_app_resource_dir('ibeis'), 'ibeis_bash_complete.sh')
+        bash_completer = ut.unixjoin(ut.ensure_app_resource_dir('wbia'), 'wbia_bash_complete.sh')
         ut.writeto(bash_completer, line)
         print('ADD TO BASHRC\nsource %s' % (bash_completer,))
         #print(line)

--- a/utool/util_ubuntu.py
+++ b/utool/util_ubuntu.py
@@ -305,7 +305,7 @@ class XCtrl(object):
         try:
             import wbia.plottool.screeninfo as screeninfo
         except ImportError:
-            import plottool.screeninfo as screeninfo
+            import wbia.plottool.screeninfo as screeninfo
         monitor_infos = {
             i + 1: screeninfo.get_resolution_info(i)
             for i in range(2)


### PR DESCRIPTION
- Rename ibeis references to wbia

  We are renaming our repos from ibeis to wbia.
  
  ```
  git grep -l  ibeis ':(exclude)_page' | xargs sed -i 's/\([^\/]\)ibeis/\1wbia/g'
  git grep -l plottool ':(exclude)_page' | xargs sed -i 's/import plottool/import wbia.plottool/g'
  git grep -l guitool_wbia ':(exclude)_page' | xargs sed -i 's/guitool_wbia/wbia.guitool/g'
  ```

- Import comb from scipy.special instead of scipy.misc

  `comb` has been moved from `scipy.misc` to `scipy.special`:
  
  ```
  AttributeError: module 'scipy.misc' has no attribute 'comb'
  ```

- Custom unpickler to handle renamed modules

  We recently renamed a lot of our packages from ibeis to wbia.  This
  caused errors during doctests like:
  
  ```
    File "/wbia/wbia-plugin-cnn/wbia_cnn/_plugin.py", line 876, in generate_species_background
      model_state = ut.load_cPkl(model_state_fpath)
    File "/wbia/utool/utool/util_io.py", line 342, in load_cPkl
      data = pickle.load(file_, encoding='latin1')
  ModuleNotFoundError: No module named 'ibeis_cnn'
  ```
  
  In order to fix this, I created a custom unpickler and overridden the
  `find_class` method to replace the module names and function names from
  ibeis to wbia.  This will probably need further adjustments as we go
  through more examples of pickled files.
