### PR TITLE
Fix string type checking code to be py2 and py3 compatible

### DIFF
--- a/utool/Printable.py
+++ b/utool/Printable.py
@@ -150,7 +150,12 @@ def printableVal(val, type_bit=True, justlength=False):
                 '{ shape:' + info.shapestr + ' mM:' + info.minmaxstr + ' }'
             )  # + '\n  |_____'
     # String
-    elif isinstance(val, (str, unicode)):  # NOQA
+    elif (
+        six.PY2
+        and isinstance(val, (str, unicode))  # NOQA
+        or six.PY3
+        and isinstance(val, (bytes, str))
+    ):
         _valstr = "'%s'" % val
     # List
     elif isinstance(val, list):


### PR DESCRIPTION
When running in python 3:

```
  File "/wbia/utool/utool/Printable.py", line 153, in printableVal
    elif isinstance(val, (str, unicode)):  # NOQA
NameError: name 'unicode' is not defined
```

In python 2, the string types are `str` and `unicode`, the equivalent in
python 3 are `bytes` and `str` respectively.  So just change the code to
use different types for python 2 and 3.