### PR TITLE
Use find_packages() in setup.py to fix missing module in wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from os.path import exists
 from collections import OrderedDict
 
-# from setuptools import find_packages
+from setuptools import find_packages
 from skbuild import setup
 
 
@@ -211,8 +211,7 @@ KWARGS = OrderedDict(
         'tag_regex': '^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$',
         'local_scheme': 'dirty-tag',
     },
-    # packages=find_packages(),
-    packages=['utool', 'utool._internal', 'utool.tests', 'utool.util_scripts'],
+    packages=find_packages() + ['utool.util_scripts'],
     package_dir={'utool': 'utool'},
     include_package_data=False,
     # List of classifiers available at:


### PR DESCRIPTION
When installing `wbia-utool` using the wheel on pypi, `utool.experimental` is
not available:

```
  File "/home/runner/work/wildbook-ia/wildbook-ia/wbia/algo/verif/vsone.py", line 925, in task_evaluation_report
    from utool.experimental.pandas_highlight import to_string_monkey
ModuleNotFoundError: No module named 'utool.experimental'
```

The directory `experimental` isn't in the wheel.  The reason seems to be that
we manually set the packages to a specific list which didn't include
`utool.experimental`.  To avoid having the same error, just use
`setuptools.find_packages`.