### PR TITLE
Change StopIteration to return in generators

### DIFF
--- a/utool/util_dev.py
+++ b/utool/util_dev.py
@@ -1081,13 +1081,13 @@ class InteractiveIter(object):
                 iiter.iterable, lbl='nointeract: ', freq=1, adjust=False
             ):
                 yield item
-            raise StopIteration()
+            return
         assert isinstance(iiter.iterable, INDEXABLE_TYPES), 'input is not iterable'
         iiter.num_items = len(iiter.iterable)
         if iiter.verbose:
             print('[IITER] Begin interactive iteration: %r items\n' % (iiter.num_items))
         if iiter.num_items == 0:
-            raise StopIteration
+            return
         # TODO: replace with ub.ProgIter
         mark_, end_ = util_progress.log_progress(
             length=iiter.num_items, lbl='interaction: ', freq=1
@@ -1307,7 +1307,7 @@ def delayed_retry_gen(delay_schedule=[0.1, 1, 10], msg=None, timeout=None, raise
             if raise_:
                 raise Exception('Retry loop timed out')
             else:
-                raise StopIteration('Retry loop timed out')
+                return
         index = min(count, len(delay_schedule) - 1)
         delay = delay_schedule[index]
         time.sleep(delay)

--- a/utool/util_parallel.py
+++ b/utool/util_parallel.py
@@ -896,7 +896,7 @@ def buffered_generator(source_gen, buffer_size=2, use_multiprocessing=False):
         # output = buffer_.get(timeout=1.0)
         output = buffer_.get()
         if output is sentinal:
-            raise StopIteration
+            return
         yield output
 
     # _iter = iter(buffer_.get, sentinal)


### PR DESCRIPTION
Python 3.7 changed the way generators work.  Code like this:

```
def gen():
    yield 'a'
    yield 'b'
    raise StopIteration

for i in gen():
    print(i)
```

causes an exception in python 3.7:

```
(py3) root@f36c5a2313f9:/wbia/wildbook-ia# python3.6 /tmp/test_generator.py
a
b
(py3) root@f36c5a2313f9:/wbia/wildbook-ia# python3.7 /tmp/test_generator.py
a
b
Traceback (most recent call last):
  File "/tmp/test_generator.py", line 4, in gen
    raise StopIteration()
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tmp/test_generator.py", line 6, in <module>
    for i in gen():
RuntimeError: generator raised StopIteration
```

It can be fixed by doing `return` instead of `raise StopIteration`.

Close #18