### PR TITLE
Fix sklearn module move in scikit-learn 0.24.0

### DIFF
--- a/utool/util_io.py
+++ b/utool/util_io.py
@@ -272,6 +272,7 @@ def save_cPkl(fpath, data, verbose=None, n=None):
 class FixRenamedUnpickler(pickle.Unpickler):
     def find_class(self, module, name):
         module = module.replace('ibeis', 'wbia')
+        module = module.replace('sklearn.preprocessing.label', 'sklearn.preprocessing')
         name = name.replace('ibeis', 'wbia')
         return super(FixRenamedUnpickler, self).find_class(module, name)
 


### PR DESCRIPTION
`sklearn.preprocessing.label` is now in `sklearn.preprocessing` instead.

```
Traceback (most recent call last):
  File "/wbia/wildbook-ia/wbia/dtool/depcache_table.py", line 1750, in _chunk_compute_dirty_rows
    config,
  File "/wbia/wildbook-ia/wbia/dtool/depcache_table.py", line 1680, in _compute_dirty_rows
    proptup_gen = list(proptup_gen)
  File "/wbia/wildbook-ia/wbia/core_annots.py", line 805, in compute_probchip
    grouped_probchips.append(list(gen))
  File "/wbia/wildbook-ia/wbia/core_annots.py", line 831, in cnn_probchips
    for chunk in ut.ichunks(mask_gen, 256):
  File "/wbia/wbia-utool/utool/util_iter.py", line 439, in ichunks_noborder
    for chunk in chunks_with_sentinals:
  File "/wbia/wbia-plugin-cnn/wbia_cnn/_plugin.py", line 1002, in generate_species_background
    model_state = ut.load_cPkl(model_state_fpath)
  File "/wbia/wbia-utool/utool/util_io.py", line 362, in load_cPkl
    data = FixRenamedUnpickler(file_, encoding='latin1').load()
  File "/wbia/wbia-utool/utool/util_io.py", line 276, in find_class
    return super(FixRenamedUnpickler, self).find_class(module, name)
ModuleNotFoundError: No module named 'sklearn.preprocessing.label'
```